### PR TITLE
Make setup.py Python3 compatible.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 try:
     from distutils.core import setup
-except ImportError, excp:
+except ImportError as excp:
     from setuptools import setup
     
 import pydot


### PR DESCRIPTION
This will allow installation directly as `pip install https://github.com/ajsteven130/pydot/zipball/master`. 
